### PR TITLE
Enable direct access to compressed bytes

### DIFF
--- a/yaecl.hpp
+++ b/yaecl.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <pybind11/pybind11.h>
 
 namespace yaecl {
 
@@ -70,6 +71,15 @@ class BitStream {
             _pos+=8;
             flen--;
         }
+    }
+    pybind11::bytes getData() {
+        return pybind11::bytes(reinterpret_cast<const char*>(_data.data()), _pos / 8 + int(_pos % 8 != 0));
+    }
+    void setData(const pybind11::bytes &data) {
+        std::string s = data;
+        _data = std::vector<uint8_t>(s.begin(), s.end());
+        _pos = _data.size() * 8;
+        _fpos = 0;
     }
   private:
     std::vector<uint8_t> _data;

--- a/yaecl_python.cpp
+++ b/yaecl_python.cpp
@@ -204,7 +204,8 @@ PYBIND11_MODULE(yaecl, m) {
         .def(init<>())
         .def("size", &bit_stream_t::size)
         .def("save", &bit_stream_t::save)
-        .def("load", &bit_stream_t::load);
+        .def("load", &bit_stream_t::load)
+        .def_property("data", &bit_stream_t::getData, &bit_stream_t::setData, "py::bytes");
     class_<ac_encoder_t>(m, "ac_encoder_t")
         .def(init<>())
         .def(init<const int &>())


### PR DESCRIPTION
In some settings it would be nice to be able to access the compressed bytes in Python without fist dumping to a file.

This PR enables direct access to the underlying compressed data in Python. This allows users to serialize these bytes using whichever technique is ideal for their application.